### PR TITLE
Fix issue with plugin causing side-effects.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ module.exports = function gulpDustCompileRender(context, opts) {
     var self = this;
 
     this.render = function dustCompileRender(data, output, callback) {
-      var i, files, thisFile, filePath, fileName, dustTags = [];
+      var i, files, thisFile, filePath, fileName, originalFormat, dustTags = [];
       //add jsdoc parameter object types to data
       data.string = "{string}";
       data.Object = "{Object}";
@@ -70,6 +70,7 @@ module.exports = function gulpDustCompileRender(context, opts) {
       }
 
       if (opts.preserveWhitespace) {
+        originalFormat = dust.optimizers.format;
         dust.optimizers.format = function returnNode(ctx, node) {
           return node;
         };
@@ -87,6 +88,9 @@ module.exports = function gulpDustCompileRender(context, opts) {
         }
       }
       dust.render("output", data, callback);
+      if (originalFormat) {
+        dust.optimizers.format = originalFormat;
+      }
     };
 
     if (file.isNull()) {


### PR DESCRIPTION
Adds a variable to save the original `format` method and restore it once the rendering is finished.
